### PR TITLE
Module update to configure widget permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9"
+    "@babel/runtime": "^7.17.9",
+    "matrix-widget-api": "^1.1.1"
   }
 }

--- a/test/RuntimeModule.test.ts
+++ b/test/RuntimeModule.test.ts
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 Mikhail Aheichyk
+Copyright 2023 Nordeck IT + Consulting GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import {Capability, Widget, MatrixWidgetType} from "matrix-widget-api";
+
+import {DefaultWidgetPermissions} from "../src/RuntimeModule";
+
+describe("RuntimeModule", () => {
+    describe("WidgetPermissions", () => {
+        const mockWidget = new Widget({
+            id: "widget-id",
+            creatorUserId: "@user-id",
+            type: MatrixWidgetType.Custom,
+            url: "https://example.com",
+        });
+
+        const defaultWidgetPermissions = new DefaultWidgetPermissions();
+
+        const customWidgetPermissions = new class extends DefaultWidgetPermissions {
+            isEmbeddingPreapproved(widget: Widget): boolean {
+                return true;
+            }
+
+            isIdentityRequestPreapproved(widget: Widget): Promise<boolean> {
+                return Promise.resolve(true);
+            }
+
+            preapproveCapabilities(widget: Widget, requestedCapabilities: Set<Capability>): Promise<Set<Capability>> {
+                return Promise.resolve(requestedCapabilities);
+            }
+        }();
+
+        it("default permissions", async () => {
+            expect(defaultWidgetPermissions.isEmbeddingPreapproved(mockWidget)).toBe(false);
+            await expect(defaultWidgetPermissions.isIdentityRequestPreapproved(mockWidget)).resolves.toBe(false);
+            await expect(
+                defaultWidgetPermissions.preapproveCapabilities(mockWidget, new Set(["org.matrix.msc2931.navigate"])),
+            ).resolves.toEqual(new Set());
+        });
+
+        it("custom permissions", async () => {
+            expect(customWidgetPermissions.isEmbeddingPreapproved(mockWidget)).toBe(true);
+            await expect(customWidgetPermissions.isIdentityRequestPreapproved(mockWidget)).resolves.toBe(true);
+            await expect(
+                customWidgetPermissions.preapproveCapabilities(mockWidget, new Set(["org.matrix.msc2931.navigate"])),
+            ).resolves.toEqual(new Set(["org.matrix.msc2931.navigate"]));
+        });
+    });
+});


### PR DESCRIPTION
We would like to have a possibility to configure widget permissions in custom fork deployments. 

These PRs: https://github.com/matrix-org/matrix-react-sdk/pull/9931, https://github.com/matrix-org/matrix-react-sdk/pull/9910 were used to try to update already existing API from matrix-react-sdk but it was agreed that module system should be used for that.

There doesn't seem to be an API currently in the module system that could be used to directly customize this behavior.

This PR suggests to update `RuntimeModule` with `WidgetPermissions` that will allow to specify widget permissions behavior in the module implementation.

In this case it will be possible to create a PR to matrix-react-sdk to:

- update [ModuleRunner](https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/modules/ModuleRunner.ts) to read `WidgetPermissions` from the [modules](https://github.com/matrix-org/matrix-react-sdk/blob/441ad40e5549470d390ef20fc347e8cb2af4f4f5/src/modules/ModuleRunner.ts#L30) and expose it via `getWidgetPermissions()`, if several modules define `WidgetPermissions` then the decision which one to use (or maybe to fail) should be made. 
- lines like https://github.com/matrix-org/matrix-react-sdk/blob/441ad40e5549470d390ef20fc347e8cb2af4f4f5/src/stores/widgets/StopGapWidgetDriver.ts#L175 should be updated to use `getWidgetPermissions()` from the `ModuleRunner`.

<!-- Please read https://github.com/matrix-org/matrix-react-sdk-module-api/blob/main/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-react-sdk-module-api/blob/main/CONTRIBUTING.md#sign-off -->
