### PR TITLE
Update the open dialog API with more options.

### DIFF
--- a/src/ModuleApi.ts
+++ b/src/ModuleApi.ts
@@ -19,6 +19,7 @@ import React from "react";
 import { PlainSubstitution, TranslationStringsObject } from "./types/translations";
 import { DialogProps } from "./components/DialogContent";
 import { AccountAuthInfo } from "./types/AccountAuthInfo";
+import { ModuleUiDialogProps } from "./types/ModuleUiDialogProps";
 
 /**
  * A module API surface for the react-sdk. Provides a stable API for modules to
@@ -46,14 +47,14 @@ export interface ModuleApi {
 
     /**
      * Opens a dialog in the client.
-     * @param title The title of the dialog
+     * @param moduleUiDialogProps Module UI Dialog props.
      * @param body The function which creates a body component for the dialog.
      * @param props Optional props to provide to the dialog.
      * @returns Whether the user submitted the dialog or closed it, and the model returned by the
      * dialog component if submitted.
      */
     openDialog<M extends object, P extends DialogProps = DialogProps, C extends React.Component = React.Component>(
-        title: string,
+        moduleUiDialogProps: ModuleUiDialogProps,
         body: (props: P, ref: React.RefObject<C>) => React.ReactNode,
         props?: Omit<P, keyof DialogProps>,
     ): Promise<{ didOkOrSubmit: boolean, model: M }>;

--- a/src/ModuleApi.ts
+++ b/src/ModuleApi.ts
@@ -47,14 +47,16 @@ export interface ModuleApi {
 
     /**
      * Opens a dialog in the client.
-     * @param titleOrOptions The title of the dialog, or an object that configures the dialog.
+     * @param initialTitleOrOptions Initial options for the dialog. Can be the title of the dialog, or a
+     *                              configuration object. Note that the dialog implementation may later
+     *                              modify its own options via the {@link DialogProps.setOptions} callback.
      * @param body The function which creates a body component for the dialog.
-     * @param props Optional props to provide to the dialog.
+     * @param props Optional props to provide to {@link body}, in addition to the common set in {@link DialogProps}.
      * @returns Whether the user submitted the dialog or closed it, and the model returned by the
      * dialog component if submitted.
      */
     openDialog<M extends object, P extends DialogProps = DialogProps, C extends DialogContent<P> = DialogContent<P>>(
-        titleOrOptions: string | ModuleUiDialogOptions,
+        initialTitleOrOptions: string | ModuleUiDialogOptions,
         body: (props: P, ref: React.RefObject<C>) => React.ReactNode,
         props?: Omit<P, keyof DialogProps>,
     ): Promise<{ didOkOrSubmit: boolean, model: M }>;

--- a/src/ModuleApi.ts
+++ b/src/ModuleApi.ts
@@ -19,7 +19,7 @@ import React from "react";
 import { PlainSubstitution, TranslationStringsObject } from "./types/translations";
 import { DialogContent, DialogProps } from "./components/DialogContent";
 import { AccountAuthInfo } from "./types/AccountAuthInfo";
-import { ModuleUiDialogProps } from "./types/ModuleUiDialogProps";
+import { ModuleUiDialogOptions } from "./types/ModuleUiDialogOptions";
 
 /**
  * A module API surface for the react-sdk. Provides a stable API for modules to
@@ -47,14 +47,14 @@ export interface ModuleApi {
 
     /**
      * Opens a dialog in the client.
-     * @param moduleUiDialogProps Module UI Dialog props.
+     * @param titleOrOptions The title of the dialog, or an object that configures the dialog.
      * @param body The function which creates a body component for the dialog.
      * @param props Optional props to provide to the dialog.
      * @returns Whether the user submitted the dialog or closed it, and the model returned by the
      * dialog component if submitted.
      */
     openDialog<M extends object, P extends DialogProps = DialogProps, C extends DialogContent<P> = DialogContent<P>>(
-        moduleUiDialogProps: ModuleUiDialogProps,
+        titleOrOptions: string | ModuleUiDialogOptions,
         body: (props: P, ref: React.RefObject<C>) => React.ReactNode,
         props?: Omit<P, keyof DialogProps>,
     ): Promise<{ didOkOrSubmit: boolean, model: M }>;

--- a/src/components/DialogContent.tsx
+++ b/src/components/DialogContent.tsx
@@ -17,22 +17,36 @@ limitations under the License.
 import * as React from "react";
 import { ModuleApi } from "../ModuleApi";
 import { PlainSubstitution } from "../types/translations";
+import { ModuleUiDialogOptions } from "../types/ModuleUiDialogOptions";
 
+/** Props for {@link DialogContent} */
 export interface DialogProps {
+    /**
+     * A reference to the active Module API .
+     */
     moduleApi: ModuleApi;
 
     /**
-     * Sets submit button as enabled or disabled on the dialog popup.
-     * @param canSubmit
+     * Updates the options of the dialog.
+     * @param options - The updates that should be applied to the dialog options.
      */
-    setCanSubmit(canSubmit: boolean): void;
+    setOptions(options: Partial<ModuleUiDialogOptions>): void;
+
+    /**
+     * Cancel the dialog programmatically.
+     */
+    cancel(): void;
 }
 
+/** State of {@link DialogContent} */
 export interface DialogState {
     busy: boolean;
     error?: string;
 }
 
+/**
+ * The content of a Dialog that was opened by the Module API.
+ */
 export abstract class DialogContent<P extends DialogProps = DialogProps, S extends DialogState = DialogState, M extends object = {}>
     extends React.PureComponent<P, S> {
 

--- a/src/components/DialogContent.tsx
+++ b/src/components/DialogContent.tsx
@@ -20,6 +20,12 @@ import { PlainSubstitution } from "../types/translations";
 
 export interface DialogProps {
     moduleApi: ModuleApi;
+
+    /**
+     * Sets submit button as enabled or disabled on the dialog popup.
+     * @param canSubmit
+     */
+    setCanSubmit(canSubmit: boolean): void;
 }
 
 export interface DialogState {

--- a/src/components/DialogContent.tsx
+++ b/src/components/DialogContent.tsx
@@ -50,8 +50,10 @@ export interface DialogState {
 }
 
 /**
- * A base class for the content of a Dialog. This can be passed to the Module API with
- * {@link ModuleApi.openDialog} to define the content inside the dialog.
+ * Base class for the content of a Dialog.
+ * 
+ * The `body` callback passed to {@link ModuleApi.openDialog} should return an instance of a
+ * class based on this.
  */
 export abstract class DialogContent<P extends DialogProps = DialogProps, S extends DialogState = DialogState, M extends object = {}>
     extends React.PureComponent<P, S> {

--- a/src/components/DialogContent.tsx
+++ b/src/components/DialogContent.tsx
@@ -19,16 +19,21 @@ import { ModuleApi } from "../ModuleApi";
 import { PlainSubstitution } from "../types/translations";
 import { ModuleUiDialogOptions } from "../types/ModuleUiDialogOptions";
 
-/** Props for {@link DialogContent} */
+/** React properties for dialog content implementations based on {@link DialogContent} */
 export interface DialogProps {
     /**
-     * A reference to the active Module API .
+     * A reference to the active Module API.
      */
     moduleApi: ModuleApi;
 
     /**
-     * Updates the options of the dialog.
-     * @param options - The updates that should be applied to the dialog options.
+     * Callback to update the dialog options.
+     * 
+     * Dialog content implementations can call this to update any of the options that were
+     * originally set via {@link ModuleApi.openDialog}.
+     * 
+     * @param options - The updates that should be applied to the dialog options. Any properties
+     * not set in the {@link options} are left unchanged.
      */
     setOptions(options: Partial<ModuleUiDialogOptions>): void;
 
@@ -45,7 +50,8 @@ export interface DialogState {
 }
 
 /**
- * The content of a Dialog that was opened by the Module API.
+ * A base class for the content of a Dialog. This can be passed to the Module API with
+ * {@link ModuleApi.openDialog} to define the content inside the dialog.
  */
 export abstract class DialogContent<P extends DialogProps = DialogProps, S extends DialogState = DialogState, M extends object = {}>
     extends React.PureComponent<P, S> {

--- a/src/types/ModuleUiDialogOptions.ts
+++ b/src/types/ModuleUiDialogOptions.ts
@@ -16,26 +16,27 @@ limitations under the License.
 */
 
 /**
- * Module UI Dialog props.
+ * Options for {@link ModuleApi#openDialog}.
  */
-export interface ModuleUiDialogProps {
+export interface ModuleUiDialogOptions {
     /**
-     * Initial value to enable or disable the dialog submit button.
-     */
-    canSubmit?: boolean;
-
-    /**
-     * Title of the dialog.
+     * The title of the dialog.
      */
     title: string;
 
     /**
-     * Cancel button label.
+     * The label of the action button. If unset, a default label will be used.
+     */
+    actionLabel?: string;
+
+    /**
+     * The label of the cancel button. If unset, a default label will be used.
      */
     cancelLabel?: string;
 
     /**
-     * Action button label.
+     * Enable or disable the action button when the dialog is created.
+     * @defaultValue The default is `true`
      */
-    actionLabel?: string;
+    canSubmit?: boolean;
 }

--- a/src/types/ModuleUiDialogProps.ts
+++ b/src/types/ModuleUiDialogProps.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 Mikhail Aheichyk
+Copyright 2023 Nordeck IT + Consulting GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Module UI Dialog props.
+ */
+export interface ModuleUiDialogProps {
+    /**
+     * Initial value to enable or disable the dialog submit button.
+     */
+    canSubmit?: boolean;
+
+    /**
+     * Title of the dialog.
+     */
+    title: string;
+
+    /**
+     * Cancel button label.
+     */
+    cancelLabel?: string;
+
+    /**
+     * Action button label.
+     */
+    actionLabel?: string;
+}


### PR DESCRIPTION
This PR suggest to update module API with more options to control rendering of the dialog shown:
1. Enable/disable dialog submit button.
2. Custom labels for cancel and submit (action) buttons.