### PR TITLE
Expose apps/widgets

### DIFF
--- a/src/ModuleApi.ts
+++ b/src/ModuleApi.ts
@@ -20,6 +20,8 @@ import { PlainSubstitution, TranslationStringsObject } from "./types/translation
 import { DialogContent, DialogProps } from "./components/DialogContent";
 import { AccountAuthInfo } from "./types/AccountAuthInfo";
 import { ModuleUiDialogOptions } from "./types/ModuleUiDialogOptions";
+import { App } from "./types/App";
+import { Container } from "./types/Container";
 
 /**
  * A module API surface for the react-sdk. Provides a stable API for modules to
@@ -120,4 +122,40 @@ export interface ModuleApi {
      * @returns The config value verbatim.
      */
     getConfigValue<T>(namespace: string, key: string): T | undefined;
+
+    /**
+     * Gets the apps for a given room.
+     *
+     * @param roomId The room ID to get the apps for.
+     * @returns The apps for the given room.
+     */
+    getApps(roomId: string): Array<App>;
+
+    /**
+     * Gets the avatar URL for an app.
+     *
+     * @param app The app to get the avatar URL for.
+     * @param width The width of the avatar.
+     * @param height The height of the avatar.
+     * @param resizeMethod The resize method to use, either "crop" or "scale".
+     */
+    getAppAvatarUrl(app: App, width?: number, height?: number, resizeMethod?: string): string | null;
+
+    /**
+     * Checks if an app is in a container for a given room.
+     *
+     * @param app The app to check.
+     * @param container The container to check.
+     * @param roomId The room ID to check.
+     */
+    isAppInContainer(app: App, container: Container, roomId: string): boolean;
+
+    /**
+     * Moves apps to containers for a given room.
+     *
+     * @param app The app to move.
+     * @param container The container to move the app to.
+     * @param roomId The room ID to move the app in.
+     */
+    moveAppToContainer(app: App, container: Container, roomId: string): void;
 }

--- a/src/types/App.ts
+++ b/src/types/App.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Nordeck IT + Consulting GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export interface App {
+    avatar_url?: string;
+    id: string;
+    name?: string;
+    type: string;
+}

--- a/src/types/Container.ts
+++ b/src/types/Container.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Nordeck IT + Consulting GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type Container = "center" | "right" | "top";


### PR DESCRIPTION
This PR exposes the apps/widgets of a room. It allows to:

- `getApps` – Gets the apps for a given room.
- `getAppAvatarUrl` – Gets the avatar URL for an app.
- `isAppInContainer` – Checks if an app is in a container for a given room.
- `moveAppToContainer` – Moves apps to containers for a given room.

Relates to https://github.com/matrix-org/matrix-react-sdk/pull/12071.

<!-- Please read https://github.com/matrix-org/matrix-react-sdk-module-api/blob/main/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-react-sdk-module-api/blob/main/CONTRIBUTING.md#sign-off -->
