### PR TITLE
Fix team reference in CODEOWNERS element-web -> element-web-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @matrix-org/element-web
+* @matrix-org/element-web-reviewers


### PR DESCRIPTION
Team was renamed from element-web -> element-web-reviewers