### PR TITLE
Add branding extensions

### DIFF
--- a/src/lifecycles/BrandingExtensions.ts
+++ b/src/lifecycles/BrandingExtensions.ts
@@ -1,0 +1,24 @@
+interface AppTitleBase {
+    brand: string;
+    syncError: boolean;
+}
+
+export interface AppTitleInRoom extends AppTitleBase {
+    brand: string;
+    roomName?: string;
+    roomId: string;
+    unreadNotificationCount: number;
+    notificationsMuted: boolean;
+}
+
+export type AppTitleContext = AppTitleBase|AppTitleInRoom;
+
+export interface ProvideBrandingExtensions {
+    getAppTitle(context: AppTitleContext): string|null;
+}
+
+export abstract class BrandingExtensionsBase implements ProvideBrandingExtensions {
+    public getAppTitle(context: AppTitleContext): string|null {
+        return null;
+    }
+}

--- a/src/lifecycles/BrandingExtensions.ts
+++ b/src/lifecycles/BrandingExtensions.ts
@@ -11,14 +11,14 @@ export interface AppTitleInRoom extends AppTitleBase {
     notificationsMuted: boolean;
 }
 
-export type AppTitleContext = AppTitleBase|AppTitleInRoom;
+export type AppTitleContext = AppTitleBase | AppTitleInRoom;
 
 export interface ProvideBrandingExtensions {
-    getAppTitle(context: AppTitleContext): string|null;
+    getAppTitle(context: AppTitleContext): string | null;
 }
 
 export abstract class BrandingExtensionsBase implements ProvideBrandingExtensions {
-    public getAppTitle(context: AppTitleContext): string|null {
+    public getAppTitle(context: AppTitleContext): string | null {
         return null;
     }
 }

--- a/src/lifecycles/BrandingExtensions.ts
+++ b/src/lifecycles/BrandingExtensions.ts
@@ -1,19 +1,42 @@
 interface AppTitleBase {
+    /**
+     * The configured brand name.
+     * @example Element
+     */
     brand: string;
+    /**
+     * Is the client sync loop in an error state.
+     */
     syncError: boolean;
+    /**
+     * The current unread notification count.
+     */
+    unreadNotificationCount?: number;
+    /**
+     * Has the client muted notifications.
+     */
+    notificationsMuted?: boolean;
 }
 
 export interface AppTitleInRoom extends AppTitleBase {
-    brand: string;
+    /**
+     * The room name, may be undefined if the room has no name.
+     */
     roomName?: string;
+    /**
+     * The room ID of the room in view.
+     */
     roomId: string;
-    unreadNotificationCount: number;
-    notificationsMuted: boolean;
 }
 
 export type AppTitleContext = AppTitleBase | AppTitleInRoom;
 
 export interface ProvideBrandingExtensions {
+    /**
+     * Called whenever the client would update the document title.
+     * @param context Current application context used to generate the title.
+     * @returns A string to be used for the full title, or null to use the default title.
+     */
     getAppTitle(context: AppTitleContext): string | null;
 }
 

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -13,10 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { ProvideBrandingExtensions } from "../lifecycles/BrandingExtensions";
 import { ProvideCryptoSetupExtensions } from "../lifecycles/CryptoSetupExtensions";
 import { ProvideExperimentalExtensions } from "../lifecycles/ExperimentalExtensions";
 
 export type AllExtensions = {
+    branding?: ProvideBrandingExtensions;
     cryptoSetup?: ProvideCryptoSetupExtensions;
     experimental?: ProvideExperimentalExtensions;
 };


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-react-sdk-module-api/blob/main/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-react-sdk-module-api/blob/main/CONTRIBUTING.md#sign-off -->

This PR adds a new extension `branding`, which allows developers to customize the app title. The intention is that whenever Element would usually try to update the app title, it would instead invoke this function to format the title based upon some context.
